### PR TITLE
Add stringset package

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,6 @@ collection of small packages with useful, common behavior
 ## flagutil
 Contains flag utilities. This includes implementations of flag.Value and flag.Getter interfaces. Also
 contains methods like ValidateFlags.
+
+## stringset
+Contains a partial implementation of a set type for strings.

--- a/stringset/stringset.go
+++ b/stringset/stringset.go
@@ -1,0 +1,102 @@
+// stringset is a library that provides set-related convenience methods around a map from string to bool.
+package stringset
+
+// A stringset is a map from a string to an empty struct. We choose empty structs because they have a size
+// of zero and make it fairly clear that this shouldn't be treated as a map.
+type StringSet map[string]struct{}
+
+// FromList converts a list of strings a StringSet
+func FromList(strings []string) StringSet {
+	set := make(map[string]struct{}, len(strings))
+	for _, str := range strings {
+		set[str] = struct{}{}
+	}
+	return set
+}
+
+// FromInterfaceList converts a list of interfaces that are known to be strings into a StringSet
+func FromInterfaceList(strings []interface{}) StringSet {
+	set := make(map[string]struct{}, len(strings))
+	for _, str := range strings {
+		set[str.(string)] = struct{}{}
+	}
+	return set
+}
+
+// ToList converts a StringSet to a list of strings
+func (inputSet StringSet) ToList() []string {
+	returnList := make([]string, 0, len(inputSet))
+	for key, _ := range inputSet {
+		returnList = append(returnList, key)
+	}
+	return returnList
+}
+
+// Clone copies a string set to a new string set
+func (s StringSet) Clone() StringSet {
+	returnSet := make(map[string]struct{}, len(s))
+	for key, value := range s {
+		returnSet[key] = value
+	}
+	return returnSet
+}
+
+// Intersect returns a new StringSet with the intersection of all the elements in both sets
+func (s1 StringSet) Intersect(s2 StringSet) StringSet {
+	return setOperation(s1, s2, true)
+}
+
+// Minus returns a new StringSet with the
+func (s1 StringSet) Minus(s2 StringSet) StringSet {
+	return setOperation(s1, s2, false)
+}
+
+// setOperation is a helper method to either intersect or subtract sets
+func setOperation(s1, s2 StringSet, wantElemsInSet2 bool) map[string]struct{} {
+	resultSet := make(map[string]struct{})
+	for key, _ := range s1 {
+		if _, ok := s2[key]; ok == wantElemsInSet2 {
+			resultSet[key] = struct{}{}
+		}
+	}
+	return resultSet
+}
+
+// AddSet adds all the elements in a string set to the operand set.
+func (s StringSet) AddSet(newValues StringSet) {
+	for newValue, _ := range newValues {
+		s[newValue] = struct{}{}
+	}
+}
+
+// AddAll adds all the elements in a string slice to the operand set.
+func (s StringSet) AddAll(newValues []string) {
+	for _, newValue := range newValues {
+		s[newValue] = struct{}{}
+	}
+}
+
+// Equals returns true if two string sets have exactly the same elements
+func (s1 StringSet) Equals(s2 StringSet) bool {
+	if len(s1) != len(s2) {
+		return false
+	}
+	for key, _ := range s1 {
+		if _, ok := s2[key]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// Partition takes in two string slices and returns a tuple with (strings only in the first set,
+// strings in both sets, strings only in the second set). It is a utility function that uses the
+// set implmentation
+func Partition(s1, s2 []string) ([]string, []string, []string) {
+	set1 := FromList(s1)
+	set2 := FromList(s2)
+	only1 := set1.Minus(set2)
+	both := set1.Intersect(set2)
+	only2 := set2.Minus(set1)
+	return only1.ToList(), both.ToList(), only2.ToList()
+}

--- a/stringset/stringset_test.go
+++ b/stringset/stringset_test.go
@@ -1,0 +1,69 @@
+package stringset
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClone(t *testing.T) {
+	initialSet := FromList([]string{"test"})
+	clonedSet := initialSet.Clone()
+
+	assert.Equal(t, initialSet, clonedSet)
+
+	delete(clonedSet, "test")
+	assert.Equal(t, 0, len(clonedSet))
+	assert.Equal(t, 1, len(initialSet))
+}
+
+func TestIntersect(t *testing.T) {
+	setA := FromList([]string{"a", "b"})
+	setB := FromList([]string{"b", "c"})
+
+	intersection := setA.Intersect(setB)
+	assert.Equal(t, intersection["b"], struct{}{})
+	assert.Equal(t, 1, len(intersection))
+}
+
+func TestMinus(t *testing.T) {
+	setA := FromList([]string{"a", "b"})
+	setB := FromList([]string{"b", "c"})
+
+	minusSet := setA.Minus(setB)
+	assert.Equal(t, minusSet["a"], struct{}{})
+	assert.Equal(t, 1, len(minusSet))
+}
+
+func TestAddingToSet(t *testing.T) {
+	setBase := FromList([]string{"a", "b"})
+
+	setBase.AddAll([]string{"a", "c"})
+	setBase.AddSet(FromList([]string{"b", "d"}))
+
+	assert.Equal(t, 4, len(setBase))
+}
+
+func TestEqual(t *testing.T) {
+	empty1 := FromList([]string{})
+	empty2 := FromList([]string{})
+	assert.True(t, empty1.Equals(empty2))
+
+	oneVariable := FromList([]string{"a"})
+	sameVariable := FromList([]string{"a"})
+	assert.True(t, oneVariable.Equals(sameVariable))
+	assert.False(t, empty1.Equals(oneVariable))
+
+	otherVariable := FromList([]string{"b"})
+	assert.False(t, oneVariable.Equals(otherVariable))
+
+	twoVariables := FromList([]string{"a", "b"})
+	assert.False(t, oneVariable.Equals(twoVariables))
+}
+
+func TestPartition(t *testing.T) {
+	a, b, c := Partition([]string{"a", "b"}, []string{"b", "c"})
+	assert.Equal(t, a, []string{"a"})
+	assert.Equal(t, b, []string{"b"})
+	assert.Equal(t, c, []string{"c"})
+}


### PR DESCRIPTION
This is simple string set wrapper around map[string]bool.

We decided to go with this instead of a generic set library for a few
reasons:
1. We wanted to avoid all the extra casting
2. It's quite simple to write a library like this
3. We had a couple custom functions we wanted to add
4. We had already written it and it was more work to switch then to just
keep using this.
