### PR TITLE
Sort by identifier functions

### DIFF
--- a/sort/byint/byint.go
+++ b/sort/byint/byint.go
@@ -1,0 +1,65 @@
+package byint
+
+import (
+	"fmt"
+	"log"
+	"reflect"
+	"sort"
+	"strconv"
+)
+
+// byInt implements sort.Interface, where Data is the slice to be sorted.
+type byInt struct {
+	Data       reflect.Value
+	Indices    []int
+	Identifier func(interface{}) int
+}
+
+// Less is a comparator. Since sort.Sort isn't stable, we use the trick of sorting [a_1, ..., a_n]
+// by sorting [(a_1, 1), ..., (a_n, n)] in lexicographical order.
+func (b byInt) Less(i, j int) bool {
+	ithVal := b.Identifier(b.Data.Index(i).Interface())
+	jthVal := b.Identifier(b.Data.Index(j).Interface())
+	if ithVal == jthVal {
+		return b.Indices[i] < b.Indices[j]
+	}
+	return ithVal < jthVal
+}
+
+// Len returns the length of the underlying data.
+func (b byInt) Len() int {
+	return b.Data.Len()
+}
+
+// Swap interchanges the i-th and j-th entries, also keeping track of their original indices.
+func (b byInt) Swap(i, j int) {
+	t := reflect.ValueOf(b.Data.Index(i).Interface())
+	b.Data.Index(i).Set(b.Data.Index(j))
+	b.Data.Index(j).Set(t)
+	b.Indices[i], b.Indices[j] = b.Indices[j], b.Indices[i]
+}
+
+// DefaultID will use the stringer interface
+func DefaultID(i interface{}) int {
+	intVal, err := strconv.Atoi(fmt.Sprint(i))
+	if err != nil {
+		log.Fatalf(err.Error())
+	}
+	return intVal
+}
+
+// Sort is a stable sort that takes a slice as first argument. Will panic if data is not a slice.
+func Sort(data interface{}, identifier ...func(interface{}) int) {
+	val := reflect.ValueOf(data)
+	identifier = append(identifier, DefaultID)
+	sortable := byInt{
+		Data:       val,
+		Indices:    make([]int, val.Len()),
+		Identifier: identifier[0],
+	}
+	for i := 0; i < val.Len(); i++ {
+		sortable.Indices[i] = i
+	}
+	sort.Sort(sortable)
+	return
+}

--- a/sort/byint/byint_test.go
+++ b/sort/byint/byint_test.go
@@ -1,0 +1,90 @@
+package byint
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type StructuredData struct {
+	Field1 int
+	Field2 string
+}
+
+func (s StructuredData) String() string {
+	return strconv.Itoa(s.Field1)
+}
+
+func TestHappyPath(t *testing.T) {
+	actual := []int{3, 2, 1, 4}
+	expected := []int{1, 2, 3, 4}
+	Sort(actual, func(i interface{}) int { return i.(int) })
+	assert.Equal(t, expected, actual)
+}
+
+func TestStableSort(t *testing.T) {
+	actual := []StructuredData{
+		{Field1: 1, Field2: "zz"},
+		{Field1: 3, Field2: "g"},
+		{Field1: 3, Field2: "h"},
+		{Field1: 2, Field2: "h"},
+		{Field1: 3, Field2: "i"},
+		{Field1: 3, Field2: "1"},
+		{Field1: 3, Field2: "o"},
+		{Field1: 2, Field2: "h"},
+		{Field1: 1, Field2: "3"},
+		{Field1: 3, Field2: "1"},
+		{Field1: 1, Field2: "1"},
+	}
+	expected := []StructuredData{
+		{Field1: 1, Field2: "zz"},
+		{Field1: 1, Field2: "3"},
+		{Field1: 1, Field2: "1"},
+		{Field1: 2, Field2: "h"},
+		{Field1: 2, Field2: "h"},
+		{Field1: 3, Field2: "g"},
+		{Field1: 3, Field2: "h"},
+		{Field1: 3, Field2: "i"},
+		{Field1: 3, Field2: "1"},
+		{Field1: 3, Field2: "o"},
+		{Field1: 3, Field2: "1"},
+	}
+	Sort(actual, func(i interface{}) int { return i.(StructuredData).Field1 })
+	assert.Equal(t, expected, actual)
+}
+
+func TestSingletonSlice(t *testing.T) {
+	actual := []string{"5"}
+	expected := []string{"5"}
+	Sort(actual)
+	assert.Equal(t, expected, actual)
+}
+
+func TestEmptySlice(t *testing.T) {
+	actual := []string{}
+	expected := []string{}
+	Sort(actual)
+	assert.Equal(t, expected, actual)
+}
+
+func TestNilSlice(t *testing.T) {
+	actual := []string(nil)
+	expected := []string(nil)
+	Sort(actual)
+	assert.Equal(t, expected, actual)
+}
+
+func TestStringerSlice(t *testing.T) {
+	actual := []StructuredData{{22, "c"}, {3, "b"}, {1, "a"}}
+	expected := []StructuredData{{1, "a"}, {3, "b"}, {22, "c"}}
+	Sort(actual)
+	assert.Equal(t, expected, actual)
+}
+
+func TestConversion(t *testing.T) {
+	actual := []string{"11", "2"}
+	expected := []string{"2", "11"}
+	Sort(actual)
+	assert.Equal(t, expected, actual)
+}

--- a/sort/bystring/bystring.go
+++ b/sort/bystring/bystring.go
@@ -1,0 +1,60 @@
+package bystring
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+)
+
+// byString implements sort.Interface, where Data is the slice to be sorted.
+type byString struct {
+	Data       reflect.Value
+	Indices    []int
+	Identifier func(interface{}) string
+}
+
+// Less is a comparator. Since sort.Sort isn't stable, we use the trick of sorting [a_1, ..., a_n]
+// by sorting [(a_1, 1), ..., (a_n, n)] in lexicographical order.
+func (b byString) Less(i, j int) bool {
+	ithVal := b.Identifier(b.Data.Index(i).Interface())
+	jthVal := b.Identifier(b.Data.Index(j).Interface())
+	if ithVal == jthVal {
+		return b.Indices[i] < b.Indices[j]
+	}
+	return ithVal < jthVal
+}
+
+// Len returns the length of the underlying data.
+func (b byString) Len() int {
+	return b.Data.Len()
+}
+
+// Swap interchanges the i-th and j-th entries, also keeping track of their original indices.
+func (b byString) Swap(i, j int) {
+	t := reflect.ValueOf(b.Data.Index(i).Interface())
+	b.Data.Index(i).Set(b.Data.Index(j))
+	b.Data.Index(j).Set(t)
+	b.Indices[i], b.Indices[j] = b.Indices[j], b.Indices[i]
+}
+
+// DefaultID will use the stringer interface
+func DefaultID(i interface{}) string {
+	return fmt.Sprint(i)
+}
+
+// Sort is a stable sort that takes a slice as first argument. Will panic if data is not a slice. No
+// compile time type safety of any type.
+func Sort(data interface{}, identifier ...func(interface{}) string) {
+	val := reflect.ValueOf(data)
+	identifier = append(identifier, DefaultID)
+	sortable := byString{
+		Data:       val,
+		Indices:    make([]int, val.Len()),
+		Identifier: identifier[0],
+	}
+	for i := 0; i < val.Len(); i++ {
+		sortable.Indices[i] = i
+	}
+	sort.Sort(sortable)
+	return
+}

--- a/sort/bystring/bystring_test.go
+++ b/sort/bystring/bystring_test.go
@@ -1,0 +1,89 @@
+package bystring
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type StructuredData struct {
+	Field1, Field2 string
+}
+
+func (s StructuredData) String() string {
+	return s.Field1 + s.Field2
+}
+
+func TestHappyPath(t *testing.T) {
+	actual := []string{"c", "b", "a", "d"}
+	expected := []string{"a", "b", "c", "d"}
+	Sort(actual, func(i interface{}) string { return i.(string) })
+	assert.Equal(t, expected, actual)
+}
+
+func TestStableSort(t *testing.T) {
+	actual := []StructuredData{
+		{Field1: "a", Field2: "zz"},
+		{Field1: "z", Field2: "g"},
+		{Field1: "z", Field2: "h"},
+		{Field1: "d", Field2: "h"},
+		{Field1: "z", Field2: "i"},
+		{Field1: "z", Field2: "1"},
+		{Field1: "z", Field2: "o"},
+		{Field1: "d", Field2: "h"},
+		{Field1: "a", Field2: "z"},
+		{Field1: "z", Field2: "a"},
+		{Field1: "a", Field2: "a"},
+	}
+	expected := []StructuredData{
+		{Field1: "a", Field2: "zz"},
+		{Field1: "a", Field2: "z"},
+		{Field1: "a", Field2: "a"},
+		{Field1: "d", Field2: "h"},
+		{Field1: "d", Field2: "h"},
+		{Field1: "z", Field2: "g"},
+		{Field1: "z", Field2: "h"},
+		{Field1: "z", Field2: "i"},
+		{Field1: "z", Field2: "1"},
+		{Field1: "z", Field2: "o"},
+		{Field1: "z", Field2: "a"},
+	}
+	Sort(actual, func(i interface{}) string { return i.(StructuredData).Field1 })
+	assert.Equal(t, expected, actual)
+}
+
+func TestSingletonSlice(t *testing.T) {
+	actual := []int{5}
+	expected := []int{5}
+	Sort(actual)
+	assert.Equal(t, expected, actual)
+}
+
+func TestEmptySlice(t *testing.T) {
+	actual := []int{}
+	expected := []int{}
+	Sort(actual)
+	assert.Equal(t, expected, actual)
+}
+
+func TestNilSlice(t *testing.T) {
+	actual := []int(nil)
+	expected := []int(nil)
+	Sort(actual)
+	assert.Equal(t, expected, actual)
+}
+
+func TestStringerSlice(t *testing.T) {
+	actual := []StructuredData{{"c", "c"}, {"b", "b"}, {"a", "a"}}
+	expected := []StructuredData{{"a", "a"}, {"b", "b"}, {"c", "c"}}
+	Sort(actual)
+	assert.Equal(t, expected, actual)
+}
+
+func TestConversion(t *testing.T) {
+	actual := []error{fmt.Errorf("B"), fmt.Errorf("A")}
+	expected := []error{fmt.Errorf("A"), fmt.Errorf("B")}
+	Sort(actual)
+	assert.Equal(t, expected, actual)
+}


### PR DESCRIPTION
@azylman I was astounded that there wasn't an easy way to sort an arbitrary slice by an identifier function... this has absolutely no type safety of any kind and will just panic if you feed it nonsense, but I have to wonder if that's enough reason not to have it.  I coded it up just to see how one might do it.  If you think it's worth having I could write a README and a Makefile, perhaps.

This allows you to do `bystring.Sort(mySlice, identifierFunction)` or `bystring.Sort(mySlice)`.  The latter works well if `mySlice` contains things that implement `fmt.Stringer`, for example, or more generally if `fmt.Sprint` does something reasonable with 'em.
